### PR TITLE
Fix broken icon image and hide footer.

### DIFF
--- a/friendly-requests-client/src/components/FaqItem.js
+++ b/friendly-requests-client/src/components/FaqItem.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import { Accordion, Icon } from 'semantic-ui-react'
+
+class FaqItem extends Component {
+
+  render() {
+    const { index, activeIndex, handleClick, faqText, faqAnswer } = this.props
+
+    return (
+      <span>
+          <Accordion.Title active={activeIndex === index} index={index} onClick={handleClick}>
+            <Icon name='dropdown' />
+            {faqText}
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === index}>
+            {faqAnswer}
+          </Accordion.Content>
+      </span>
+    )
+  }
+}
+
+export default FaqItem

--- a/friendly-requests-client/src/containers/FixedMenuLayout.js
+++ b/friendly-requests-client/src/containers/FixedMenuLayout.js
@@ -15,7 +15,6 @@ const FixedMenuLayout = () => (
         <Route exact path="/" component={HomePage}/>
         <Route path="/faq" component={FaqPage}/>
 
-        <Footer />
       </div>
     </Router>
   </div>

--- a/friendly-requests-client/src/containers/NavMenu.js
+++ b/friendly-requests-client/src/containers/NavMenu.js
@@ -1,16 +1,12 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
-import { Container, Image, Menu } from 'semantic-ui-react'
+import { Container, Icon, Image, Menu } from 'semantic-ui-react'
 
 const NavMenu = () => (
   <Menu fixed='top' inverted>
     <Container>
       <Menu.Item as='a' header>
-        <Image
-          size='mini'
-          src='/logo.png'
-          style={{ marginRight: '1.5em' }}
-        />
+        <Icon name='archive' size='large' />
         Friendly Requests
       </Menu.Item>
       <Menu.Item as='a'><Link to="/">Home</Link></Menu.Item>


### PR DESCRIPTION
Nav bar was using a non-existent image as an icon. Replaced with an archive icon. Footer had a number of placeholder links and text, hiding since there isn't relevant content to populate footer.