### PR TITLE
Fix Linter Warnings

### DIFF
--- a/friendly-requests-client/src/containers/FaqPage.js
+++ b/friendly-requests-client/src/containers/FaqPage.js
@@ -32,7 +32,7 @@ export default class FaqPage extends Component {
           <FaqItem index={2} activeIndex={activeIndex} handleClick={this.handleClick}
             faqText="How can I suggest improvements?"
             faqAnswer={
-              <p>Head on over to the <a href="https://github.com/codefordayton/friendly-requests/issues" target="_blank">Friendly Requests</a> project on GitHub, click the "New Issue" button, and suggest an improvement!</p>
+              <p>Head on over to the <a href="https://github.com/codefordayton/friendly-requests/issues" target="_blank"  rel="noopener noreferrer">Friendly Requests</a> project on GitHub, click the "New Issue" button, and suggest an improvement!</p>
             }
           />
         </Accordion>

--- a/friendly-requests-client/src/containers/FixedMenuLayout.js
+++ b/friendly-requests-client/src/containers/FixedMenuLayout.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import NavMenu from './NavMenu';
-import Footer from './Footer';
 import HomePage from './HomePage';
 import FaqPage from './FaqPage';
 


### PR DESCRIPTION
Resolved the following:

Compiled with warnings.

./src/containers/FaqPage.js
  Line 35:  Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener  react/jsx-no-target-blank

./src/containers/FixedMenuLayout.js
  Line 4:  'Footer' is defined but never used  no-unused-vars

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.